### PR TITLE
Fix typo "plastanium" on rotary-compressor.json

### DIFF
--- a/content/blocks/production/rotary-compressor.json
+++ b/content/blocks/production/rotary-compressor.json
@@ -12,7 +12,7 @@
 	"buildCostMultiplier" : 0.6,	
 	"craftEffect": "formsmoke",
 	"updateEffect" : "plasticburn",
-	"outputItem": {"item": "plastanium", "amount": 6},
+	"outputItem": {"item": "plastarium", "amount": 6},
 	"consumes": {
 		"power": 6.5,
 		"items": {


### PR DESCRIPTION
Fix typo on the output item "plastanium" -> "plastarium"
this typo cause crash when the factory is used.