### PR TITLE
Fix Rotary Compressor

### DIFF
--- a/content/blocks/production/rotary-compressor.json
+++ b/content/blocks/production/rotary-compressor.json
@@ -1,4 +1,5 @@
 {
+	"type": "GenericSmelter",
 	"name": "Rotary Compressor",
 	"description": "Bigger and more efficient than regular plastanium compressor.",
 	"health" : 1280,


### PR DESCRIPTION
the Rotary Compressor is missing "GenericSmelter" for the "type"
It cause the building is unelectable and will cause crash when there is a material entering the building.